### PR TITLE
improve the Python wrapper

### DIFF
--- a/tcc_python_scripts/file_readers/snapshot.py
+++ b/tcc_python_scripts/file_readers/snapshot.py
@@ -16,7 +16,7 @@ def stream_safe_open(path_or_file, mode='r'):
     Args:
         path_or_file: either an open file stream (in which case the context manager does nothing and returns it)
             or a path (in which case the context manager will open this, return a stream and then clean up)
-        mode: mode to open file in, 'r' for read, 'w' for write
+        mode: mode to open file in, 'r' for read, 'w' for write, 'a' for append
     """
     if isinstance(path_or_file, str):
         file_object = file_to_close = open(path_or_file, mode)
@@ -125,13 +125,16 @@ class Snapshot:
                     break
                 yield snap
 
-    def write(self, output_file):
+    def write(self, output_file, mode='w'):
         """Dump the snapshot to a file.
 
         Args:
              output_file: file or path to write the snapshot to
+             mode (str): 'w' for overwride and 'a' for append
         """
-        with stream_safe_open(output_file, 'w') as output_file:
+        if mode not in ('a', 'w'):
+            raise ValueError("Only [w]rite and [a]ppend mode are valid")
+        with stream_safe_open(output_file, mode) as output_file:
             xyz_frame = str(self)
             output_file.write(xyz_frame)
             output_file.write('\n')


### PR DESCRIPTION
I made several improvements

1. correctly implemented multiple frame analysis (again). The previous issue is that the output mode is 'w' so only the last frame will be analysed.
2. If the number of analyse frame is given by the user, then the user input have a higher priority
3. I re-implemented the function to get particle-level  information of the TCC clusters.

The minimum example to access the new function is,

```python
import numpy as np
from tcc_python_scripts.tcc import wrapper

coords = np.random.random((25, 1000, 3))
box = [1, 1, 1]

tcc = wrapper.TCCWrapper()
# only the first 10 out of 25 frames will be analysed
tcc.input_parameters['Run']['frames'] = 10
tcc.input_parameters['Output']['Raw'] = True
tcc.input_parameters['Simulation']['rcutAA'] = 0.2
tcc.clusters_to_analyse = ['sp5a', 'sp4a', 'sp3a']
tcc.run(box, coords)

# print first frame of sp5a, particles 1 - 5
cluster_dict = tcc.get_cluster_dict(tcc.clusters_to_analyse)
print("sp5a in the 1st frame: \n", cluster_dict['sp5a'][0][:5].T)

# print all clusters in the first frame
print("\nAll cluster in the 1st frame")
tables = tcc.get_cluster_table(tcc.clusters_to_analyse)
print(tables[0].head())
```

with the following result,

```
sp5a in the 1st frame: 
 [[ True  True False  True  True]]

All cluster in the 1st frame
    sp5a  sp4a   sp3a
0   True  True  False
1   True  True   True
2  False  True  False
3   True  True   True
4   True  True   True
```